### PR TITLE
include 'all_topics' in meta params

### DIFF
--- a/src/stream.js
+++ b/src/stream.js
@@ -111,6 +111,9 @@ define(['./helpers', './poller', './meta_poller', './top_things_poller', './stre
   Stream.prototype.buildMetaParams = function(opts) {
     opts = opts || {};
     var params = [];
+    if(opts.all_topics) {
+      params.push(['all_topics', opts.all_topics]);
+    }
     if(opts.disregard) {
       params.push(['disregard', opts.disregard]);
     }


### PR DESCRIPTION
@tgrochowicz 

meta wrapper doesn't account for "all_topics" param. http://dev.massrelevance.com/docs/api/v1.0/meta/#ref-params-top-topics